### PR TITLE
Change nginx upload size, Add delete project plugin for gerrit, Add 2 scripts to stop and rm docker containers

### DIFF
--- a/bootstrap/build_docker_images.sh
+++ b/bootstrap/build_docker_images.sh
@@ -33,7 +33,6 @@ if [ -z "$APP_BASE" ] ; then
   export APP_BASE
 fi
 
-
 echo "Building the docker images in $APP_BASE"
 
 echo "building the Docker image for gerrit"

--- a/bootstrap/remove-containers.sh
+++ b/bootstrap/remove-containers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+echo "Remove the devops docker containers"
+docker rm jenkins gerrit nexus gitlab

--- a/bootstrap/run-docker.sh
+++ b/bootstrap/run-docker.sh
@@ -38,8 +38,6 @@ GITLAB_USER=${GITLAB_USER:-root}
 GITLAB_PASSWORD=${GITLAB_PASSWORD:-redhat01}
 GITLAB_PROJ_ROOT=${GITLAB_PROJ_ROOT:-root}
 
-
-
 echo "Creating the docker images using gitlab user ${GITLAB_USER} and project root '${GITLAB_PROJ_ROOT}'"
 docker run -itdP --name gitlab -e 'GITLAB_SIGNUP=true' --privileged sameersbn/gitlab:7.2.2
 docker run -itdP --name gerrit --env GITLAB_USER=$GITLAB_USER --env GITLAB_PASSWORD=$GITLAB_PASSWORD --env GITLAB_PROJ_ROOT=$GITLAB_PROJ_ROOT --link gitlab:gitlab fabric8:gerrit

--- a/bootstrap/run-docker.sh
+++ b/bootstrap/run-docker.sh
@@ -39,7 +39,7 @@ GITLAB_PASSWORD=${GITLAB_PASSWORD:-redhat01}
 GITLAB_PROJ_ROOT=${GITLAB_PROJ_ROOT:-root}
 
 echo "Creating the docker images using gitlab user ${GITLAB_USER} and project root '${GITLAB_PROJ_ROOT}'"
-docker run -itdP --name gitlab -e 'GITLAB_SIGNUP=true' --privileged sameersbn/gitlab:7.2.2
+docker run -itdP --name gitlab -e 'GITLAB_SIGNUP=true' -e 'NGINX_MAX_UPLOAD_SIZE=100m' --privileged sameersbn/gitlab:7.2.2
 docker run -itdP --name gerrit --env GITLAB_USER=$GITLAB_USER --env GITLAB_PASSWORD=$GITLAB_PASSWORD --env GITLAB_PROJ_ROOT=$GITLAB_PROJ_ROOT --link gitlab:gitlab fabric8:gerrit
 docker run -itdP --name nexus pantinor/centos-nexus:latest
 docker run -itdP --name jenkins --link gitlab:gitlab --link nexus:nexus --link gerrit:gerrit --privileged fabric8:jenkins

--- a/bootstrap/stop-containers.sh
+++ b/bootstrap/stop-containers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+echo "Stopping the devops docker containers"
+docker stop jenkins gerrit nexus gitlab

--- a/gerrit-docker/Dockerfile
+++ b/gerrit-docker/Dockerfile
@@ -1,7 +1,7 @@
 #Example how to run this:
 # docker run -itdP --name=“gerrit” -e “GERRIT_USER=admin” -e “GERRIT_PASSWORD=redhat01” -e \
 # “GERRIT_PROJ_ROOT=root”--link gitlab:gitlab gerrit
-FROM  ubuntu:trusty
+FROM ubuntu:trusty
 
 MAINTAINER Christian Posta <christian.posta@gmail.com>
 
@@ -21,11 +21,10 @@ RUN useradd -m ${GERRIT_USER}
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes tzdata=2014b-1 tzdata-java openjdk-6-jre-headless sudo git-core supervisor vim-tiny
 RUN mkdir -p /var/log/supervisor
 
-ADD http://gerrit-releases.storage.googleapis.com/gerrit-2.8.5.war /tmp/gerrit.war
-#ADD gerrit-2.8.war /tmp/gerrit.war
+ADD https://gerrit-releases.storage.googleapis.com/gerrit-2.8.5.war /tmp/gerrit.war
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-RUN mkdir -p $GERRIT_HOME/gerrit
+RUN mkdir -p $GERRIT_HOME/gerrit && mkdir -p ${GERRIT_HOME}/gerrit/plugins
 RUN mv /tmp/gerrit.war $GERRIT_WAR
 ADD replication.config $GERRIT_HOME/gerrit/etc/replication.config
 ADD conf-and-run-gerrit.sh $GERRIT_HOME/conf-and-run-gerrit.sh
@@ -33,7 +32,8 @@ RUN chmod +x $GERRIT_HOME/conf-and-run-gerrit.sh
 
 RUN chown -R ${GERRIT_USER}:${GERRIT_USER} $GERRIT_HOME
 
-
+# Download gerrit plugin
+ADD http://ci.gerritforge.com/view/Plugins-stable-2.9/job/Plugin_delete-project_stable-2.9/lastSuccessfulBuild/artifact/target/delete-project-2.9.jar ${GERRIT_HOME}/gerrit/plugins/delete-project.jar
 
 USER gerrit
 RUN java -jar $GERRIT_WAR init --install-plugin=replication --batch -d $GERRIT_HOME/gerrit
@@ -47,7 +47,6 @@ ADD gerrit.config $GERRIT_HOME/gerrit/etc/gerrit.config
 ## admin user
 #ADD db/ReviewDB.h2.db $GERRIT_HOME/gerrit/db/ReviewDB.h2.db
 #RUN chmod 644 $GERRIT_HOME/gerrit/db/ReviewDB.h2.db
-
 
 RUN chown -R ${GERRIT_USER}:${GERRIT_USER} $GERRIT_HOME
 


### PR DESCRIPTION
- Add 2 scripts to stop and rm docker containers
- Create plugins directory under $GERRIT_HOME/gerrit/plusigs
- Add delete project plugin for gerrit docker. Why : By default the web front end of gerrit does not support to delete a project. the only option is to use the plugin "delete-project" with this command :
`ssh -i ~/.ssh/id_redhat_rsa  -p 32804 admin@192.168.59.103 deleteproject delete --yes-really-delete demo`
where demo is the name of the project to be deleted, -p the ssh port number of the gerrit docker container
- Add NGINX_MAX_UPLOAD_SIZE=100 env variable to avoid the issue reported #6 